### PR TITLE
Fix: Kicad: Fileformat pad fix

### DIFF
--- a/src/faebryk/exporters/pcb/kicad/transformer.py
+++ b/src/faebryk/exporters/pcb/kicad/transformer.py
@@ -45,7 +45,7 @@ from faebryk.libs.kicad.fileformats import (
     C_xyz,
 )
 from faebryk.libs.sexp.dataclass_sexp import dataclass_dfs
-from faebryk.libs.util import cast_assert, find, get_key
+from faebryk.libs.util import KeyErrorAmbiguous, cast_assert, find, get_key
 from shapely import Polygon
 from typing_extensions import deprecated
 
@@ -259,9 +259,12 @@ class PCB_Transformer:
 
             pin_names = g_fp.get_trait(has_kicad_footprint).get_pin_names()
             for fpad in g_fp.IFs.get_all():
-                pad = find(
-                    fp.pads, lambda p: p.name == pin_names[cast_assert(FPad, fpad)]
-                )
+                try:
+                    pad = find(
+                        fp.pads, lambda p: p.name == pin_names[cast_assert(FPad, fpad)]
+                    )
+                except KeyErrorAmbiguous as e:
+                    pad = e.duplicates[0]
                 fpad.add_trait(
                     PCB_Transformer.has_linked_kicad_pad_defined(fp, pad, self)
                 )

--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -611,6 +611,7 @@ class C_footprint:
             circle = auto()
             rect = auto()
             roundrect = auto()
+            oval = auto()
 
         @dataclass
         class C_options:


### PR DESCRIPTION
# Fix: Kicad: Fileformat pad fix

# Description

Merge with Rubens PR!


# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
