### PR TITLE
Core: Add get_trait_or helper

### DIFF
--- a/src/faebryk/core/trait.py
+++ b/src/faebryk/core/trait.py
@@ -3,9 +3,18 @@
 import logging
 
 from faebryk.core.node import Node
+from faebryk.libs.exceptions import FaebrykException
 from faebryk.libs.util import cast_assert
 
 logger = logging.getLogger(__name__)
+
+
+class TraitException(FaebrykException):
+    """Raised for trait related errors."""
+
+
+class TraitNotFoundError(TraitException):
+    """Raised when a trait is not found."""
 
 
 class Trait(Node):


### PR DESCRIPTION
# Description

Add `get_trait_or` which acts like `dict.get`. I'd prefer to not mix up the "get" name, but this is the best overall I came up with. It helps because then you can chain things like `if trait := n.get_trait_or(...): ...`

Additionally, it expands the use of Faebryk exceptions, instead of assertions

# Checklist

N/A - merge back to PR in progress