### PR TITLE
Fontlayout: Speedup, show progress per polygon

### DIFF
--- a/src/faebryk/exporters/pcb/layout/font.py
+++ b/src/faebryk/exporters/pcb/layout/font.py
@@ -11,7 +11,7 @@ from faebryk.library.has_pcb_position_defined_relative_to_parent import (
 )
 from faebryk.libs.font import Font
 from faebryk.libs.geometry.basic import get_distributed_points_in_polygon
-from rich.progress import track
+from rich.progress import Progress
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +47,17 @@ class FontLayout(Layout):
 
         logger.info(f"Finding points in polygons with density: {density}")
         nodes = []
-        for p in track(polys, description="Finding points in polygons"):
-            nodes.extend(get_distributed_points_in_polygon(polygon=p, density=density))
+        with Progress(*Progress.get_default_columns()) as progress:
+            tasks = [
+                progress.add_task(f"Converging points for polygon {i}", total=100)
+                for i, _ in enumerate(polys)
+            ]
+            for i, p in enumerate(polys):
+                nodes.extend(
+                    get_distributed_points_in_polygon(
+                        polygon=p, density=density, progress=progress, task_id=tasks[i]
+                    )
+                )
 
         logger.info(f"Creating {len(nodes)} nodes in polygons")
 

--- a/src/faebryk/libs/geometry/basic.py
+++ b/src/faebryk/libs/geometry/basic.py
@@ -14,6 +14,22 @@ from shapely.ops import nearest_points
 logger = logging.getLogger(__name__)
 
 
+def get_point_on_bezier_curve(p, t: float) -> np.ndarray:
+    """
+    Get a point on a quadratic bezier curve
+
+    :param p: The points, including the start and end points
+    :param t: The parameter t [0, 1]
+    :return: The point on the curve
+    """
+    if len(p) == 1:
+        return p[0]
+    else:
+        return (1 - t) * get_point_on_bezier_curve(
+            p[:-1], t
+        ) + t * get_point_on_bezier_curve(p[1:], t)
+
+
 def polygon_insert_cutout(polygon: Polygon, cutout: Polygon) -> Polygon:
     """
     Insert a cutout into a polygon

--- a/src/faebryk/libs/geometry/basic.py
+++ b/src/faebryk/libs/geometry/basic.py
@@ -184,7 +184,9 @@ def get_distributed_points_in_polygon(
             progress.update(
                 task_id,
                 completed=max(
-                    (100 * convergence_threshold) / max(point_distance_travel), 100
+                    (100 * convergence_threshold)
+                    / max(point_distance_travel + [convergence_threshold]),
+                    100,
                 ),
             )
 

--- a/src/faebryk/libs/geometry/basic.py
+++ b/src/faebryk/libs/geometry/basic.py
@@ -128,6 +128,10 @@ def get_distributed_points_in_polygon(
     size_x = max_x - min_x
     size_y = max_y - min_y
 
+    # iterate until threshold, then force points to be inside the polygon and iterate
+    # again
+    force_in_polygon = False
+
     while True:
         point_distance_travel = []
         for i, point in enumerate(points):
@@ -178,7 +182,7 @@ def get_distributed_points_in_polygon(
 
             new_point = point_bubble.centroid
 
-            if not point_bubble.contains(new_point):
+            if force_in_polygon and not point_bubble.contains(new_point):
                 new_point, _ = nearest_points(polygon, new_point)
 
             point_distance_travel.append(
@@ -205,7 +209,9 @@ def get_distributed_points_in_polygon(
             )
 
         if max(point_distance_travel + [0]) < convergence_threshold:
-            break
+            if force_in_polygon:
+                break
+            force_in_polygon = True
 
     return points
 

--- a/src/faebryk/libs/geometry/basic.py
+++ b/src/faebryk/libs/geometry/basic.py
@@ -82,7 +82,7 @@ def get_distributed_points_in_polygon(
     polygon: Polygon,
     density: float,
     max_points: int = 50,
-    convergence_threshold: float = 0.05,
+    convergence_threshold: float = 0.02,
     progress: Progress | None = None,
     task_id: TaskID | None = None,
 ) -> list[Point]:


### PR DESCRIPTION
# Fontlayout: Speedup, show progress per polygon

# Description

Reopened from https://github.com/faebryk/faebryk/pull/213


- Speedup by introducing a convergence threshold and a maximum number of points per polygon
- Add option for showing progress per polygon
- Add bezier support
- Add support for multiline strings in `string_to_polygons()`

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
