### PR TITLE
Bug: KiCad: Fileformat: missing island, dnp, via

### DIFF
--- a/src/faebryk/exporters/pcb/kicad/transformer.py
+++ b/src/faebryk/exporters/pcb/kicad/transformer.py
@@ -533,7 +533,7 @@ class PCB_Transformer:
         self.pcb.vias.append(
             Via(
                 at=C_xy(*coord),
-                size=C_wh(size_drill[0], size_drill[0]),
+                size=size_drill[0],
                 drill=size_drill[1],
                 layers=["F.Cu", "B.Cu"],
                 net=net,

--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -963,6 +963,9 @@ class C_kicad_pcb_file(SEXP_File):
             @dataclass(kw_only=True)
             class C_filled_polygon:
                 layer: str
+                island: Optional[bool] = field(
+                    **sexp_field(positional=True), default=None
+                )
                 pts: C_polygon.C_pts
 
             net: int

--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -884,7 +884,7 @@ class C_kicad_pcb_file(SEXP_File):
         @dataclass
         class C_via:
             at: C_xy
-            size: C_wh
+            size: float
             drill: float
             net: int
             uuid: UUID

--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -622,6 +622,7 @@ class C_polygon:
 class C_footprint:
     class E_attr(SymEnum):
         smd = auto()
+        dnp = auto()
         board_only = auto()
         through_hole = auto()
         exclude_from_pos_files = auto()


### PR DESCRIPTION
# Bug: KiCad: Fileformat: missing island, dnp, via

## Description

- [Fix: vias only have 1 size value](https://github.com/atopile/faebryk/commit/54a747e4908f5f1a13555d4c0eae2968451d5aac)
- [Add: DNP footprint attr](https://github.com/atopile/faebryk/commit/85729e92abd4cf8d9d900442fd3fb1f37c2859e2)
- [Add: Island bool for filled polygons](https://github.com/atopile/faebryk/commit/2aa0fb9dc93fe28f3ac097e36fe65a5dcf2b1e8d)

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
