### PR TITLE
Tools: Add lcsc & mfr flag to libadd for auto-module

### DIFF
--- a/src/faebryk/libs/picker/jlcpcb/jlcpcb.py
+++ b/src/faebryk/libs/picker/jlcpcb/jlcpcb.py
@@ -364,6 +364,10 @@ class Component(Model):
                 f"{indent(module.pretty_params(), ' '*4)}"
             )
 
+    @property
+    def mfr_name(self) -> str:
+        return asyncio.run(Manufacturers().get_from_id(self.manufacturer_id))
+
 
 class ComponentQuery:
     class Error(Exception): ...
@@ -482,6 +486,8 @@ class ComponentQuery:
 
     def filter_by_manufacturer(self, manufacturer: str) -> Self:
         assert self.Q
+        if not manufacturer:
+            return self
         manufacturer_ids = asyncio.run(Manufacturers().get_ids(manufacturer))
         self.Q &= Q(manufacturer_id__in=manufacturer_ids)
         return self

--- a/src/faebryk/libs/picker/jlcpcb/pickers.py
+++ b/src/faebryk/libs/picker/jlcpcb/pickers.py
@@ -86,8 +86,8 @@ def add_jlcpcb_pickers(module: Module, base_prio: int = 0) -> None:
 
     # Generic pickers
     prio = base_prio
-    module.add(F.has_multi_picker(prio, JLCPCBPicker(P.find_lcsc_part)))
-    module.add(F.has_multi_picker(prio, JLCPCBPicker(P.find_manufacturer_part)))
+    module.add(F.has_multi_picker(prio, JLCPCBPicker(P.find_and_attach_by_lcsc_id)))
+    module.add(F.has_multi_picker(prio, JLCPCBPicker(P.find_and_attach_by_mfr)))
 
     # Type specific pickers
     prio = base_prio + 1

--- a/src/faebryk/tools/libadd.py
+++ b/src/faebryk/tools/libadd.py
@@ -2,14 +2,30 @@
 # SPDX-License-Identifier: MIT
 
 import glob
+import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
-import black
 import typer
+from more_itertools import partition
 
+from faebryk.libs.picker.jlcpcb.jlcpcb import Component
+from faebryk.libs.picker.jlcpcb.picker_lib import (
+    find_component_by_lcsc_id,
+    find_component_by_mfr,
+)
+from faebryk.libs.picker.lcsc import download_easyeda_info
+from faebryk.libs.pycodegen import (
+    fix_indent,
+    format_and_write,
+    gen_block,
+    gen_repeated_block,
+    sanitize_name,
+)
 from faebryk.libs.tools.typer import typer_callback
+from faebryk.libs.util import KeyErrorAmbiguous, KeyErrorNotFound, find
 
 # TODO use AST instead of string
 
@@ -18,6 +34,7 @@ from faebryk.libs.tools.typer import typer_callback
 class CTX:
     path: Path
     pypath: str
+    overwrite: bool
 
 
 def get_ctx(ctx: typer.Context) -> "CTX":
@@ -28,9 +45,11 @@ def write(ctx: typer.Context, contents: str, filename=""):
     path: Path = get_ctx(ctx).path
     if filename:
         path = path.with_stem(filename)
-    contents = contents.strip()
-    contents = black.format_file_contents(contents, fast=True, mode=black.FileMode())
-    path.write_text(contents)
+
+    if path.exists() and not get_ctx(ctx).overwrite:
+        raise FileExistsError(f"File {path} already exists")
+
+    format_and_write(contents, path)
 
     typer.echo(f"File {path} created")
 
@@ -72,43 +91,158 @@ def main(ctx: typer.Context, name: str, local: bool = True, overwrite: bool = Fa
             f"Library folder {libfolder} not found, are you in the right directory?"
         )
 
-    path = (libfolder / name).with_suffix(".py")
+    path = libfolder / (name + ".py")
 
-    if path.exists() and not overwrite:
-        raise FileExistsError(f"File {path} already exists")
-
-    ctx.obj = CTX(path=path, pypath=pypath)
+    ctx.obj = CTX(path=path, pypath=pypath, overwrite=overwrite)
 
 
 @main.command()
-def module(ctx: typer.Context, interface: bool = False):
+def module(
+    ctx: typer.Context, interface: bool = False, mfr: bool = False, lcsc: bool = False
+):
+    name = get_name(ctx)
+
+    docstring = "TODO: Docstring describing your module"
     base = "Module" if not interface else "ModuleInterface"
 
-    out = dedent(f"""
+    part: Component | None = None
+    traits = []
+    nodes = []
+
+    imports = [
+        "import faebryk.library._F as F  # noqa: F401",
+        f"from faebryk.core.{base.lower()} import {base}",
+        "from faebryk.libs.library import L  # noqa: F401",
+        "from faebryk.libs.units import P  # noqa: F401",
+    ]
+
+    if mfr and lcsc:
+        raise ValueError("Cannot use both mfr and lcsc")
+    if mfr or lcsc:
+        import faebryk.libs.picker.lcsc as lcsc_
+
+        BUILD_DIR = Path("./build")
+        lcsc_.BUILD_FOLDER = BUILD_DIR
+        lcsc_.LIB_FOLDER = BUILD_DIR / Path("kicad/libs")
+        lcsc_.MODEL_PATH = None
+
+    if lcsc:
+        part = find_component_by_lcsc_id(name)
+        traits.append(
+            "lcsc_id = L.f_field(F.has_descriptive_properties_defined)"
+            f"({{'LCSC': '{name}'}})"
+        )
+    elif mfr:
+        if "," in name:
+            mfr_, mfr_pn = name.split(",", maxsplit=1)
+        else:
+            mfr_, mfr_pn = "", name
+        try:
+            part = find_component_by_mfr(mfr_, mfr_pn)
+        except KeyErrorAmbiguous as e:
+            # try find exact match
+            try:
+                part = find(e.duplicates, lambda x: x.mfr == mfr_pn)
+            except KeyErrorNotFound:
+                print(
+                    f"Error: Ambiguous mfr_pn({mfr_pn}):"
+                    f" {[x.mfr for x in e.duplicates]}"
+                )
+                print("Tip: Specify the full mfr_pn of your choice")
+                sys.exit(1)
+
+    if part:
+        name = sanitize_name(f"{part.mfr_name}_{part.mfr}")
+        assert isinstance(name, str)
+        ki_footprint, _, easyeda_footprint, _, easyeda_symbol = download_easyeda_info(
+            part.partno, get_model=False
+        )
+
+        designator_prefix = easyeda_symbol.info.prefix.replace("?", "")
+        traits.append(
+            f"designator_prefix = L.f_field(F.has_designator_prefix_defined)"
+            f"('{designator_prefix}')"
+        )
+
+        imports.append("from faebryk.libs.picker.picker import DescriptiveProperties")
+        traits.append(
+            f"descriptive_properties = L.f_field(F.has_descriptive_properties_defined)"
+            f"({{DescriptiveProperties.manufacturer: '{part.mfr_name}', "
+            f"DescriptiveProperties.partno: '{part.mfr}'}})"
+        )
+
+        if part.datasheet:
+            traits.append(
+                f"datasheet = L.f_field(F.has_datasheet_defined)('{part.datasheet}')"
+            )
+
+        partdoc = part.description.replace("  ", "\n")
+        docstring = f"{docstring}\n\n{partdoc}"
+
+        # pins --------------------------------
+        pins = [
+            (pin.settings.spice_pin_number, pin.name.text)
+            for pin in easyeda_symbol.pins
+        ]
+        pins, noname = partition(lambda x: re.match(r"[0-9]+", x[1]), pins)
+        pins = sorted(pins, key=lambda x: x[0])
+        noname = list(noname)
+        assert all(k == v for k, v in noname)
+        noname = [k for k, v in sorted(noname, key=lambda x: int(x[0]))]
+        noname = {pin_num: i for i, pin_num in enumerate(noname)}
+
+        interface_names = {
+            pin_name: sanitize_name(pin_name)
+            for _, pin_name in sorted(pins, key=lambda x: x[1])
+        }
+
+        nodes.append(
+            "#TODO: Change auto-generated interface types to actual high level types"
+        )
+        nodes += [f"{pin_name}: F.Electrical" for pin_name in interface_names.values()]
+        if noname:
+            nodes.append(f"unnamed = L.list_field({len(noname)}, F.Electrical)")
+
+        traits.append(f"""
+            @L.rt_field
+            def pin_association_heuristic(self):
+                return F.has_pin_association_heuristic_lookup_table(
+                    mapping={{
+                        {", ".join([f"self.{interface_names[pin_name]}: ['{pin_name}']"
+                                    for _,pin_name in pins] + [
+                                        f"self.unnamed[{i}]: ['{pin_num}']"
+                                        for pin_num, i in noname.items()
+                                    ])}
+                    }},
+                    accept_prefix=False,
+                    case_sensitive=False,
+                )
+        """)
+
+    out = fix_indent(f"""
         # This file is part of the faebryk project
         # SPDX-License-Identifier: MIT
 
         import logging
 
-        import faebryk.library._F as F  # noqa: F401
-        from faebryk.core.{base.lower()} import {base}
-        from faebryk.libs.library import L  # noqa: F401
-        from faebryk.libs.units import P  # noqa: F401
+        {gen_repeated_block(imports)}
 
         logger = logging.getLogger(__name__)
 
-        class {get_name(ctx)}({base}):
+        class {name}({base}):
             \"\"\"
-            Docstring describing your module
+            {gen_block(docstring)}
             \"\"\"
 
             # ----------------------------------------
             #     modules, interfaces, parameters
             # ----------------------------------------
+            {gen_repeated_block(nodes)}
 
             # ----------------------------------------
             #                 traits
             # ----------------------------------------
+            {gen_repeated_block(traits)}
 
             def __preinit__(self):
                 # ------------------------------------
@@ -121,7 +255,7 @@ def module(ctx: typer.Context, interface: bool = False):
                 pass
     """)
 
-    write(ctx, out)
+    write(ctx, out, filename=name)
 
 
 @main.command()


### PR DESCRIPTION
# Tools: Add lcsc & mfr flag to libadd for auto-module 

# Description

Adding --mfr or --lcsc to libadd will now result in automatically adding
datasheets, designator, name, descriptive\_properties, interfaces & pin
heuristics to the module.

`❯ faebryk libadd STM32G030K6T6 module --mfr`
![image](https://github.com/user-attachments/assets/60716529-d42d-43d2-b7ad-da8f11f3644d)
```python
# This file is part of the faebryk project
# SPDX-License-Identifier: MIT

import logging

import faebryk.library._F as F  # noqa: F401
from faebryk.core.module import Module
from faebryk.libs.library import L  # noqa: F401
from faebryk.libs.picker.picker import DescriptiveProperties
from faebryk.libs.units import P  # noqa: F401

logger = logging.getLogger(__name__)


class STMicroelectronics_STM32G030K6T6(Module):
    """
    TODO: Docstring describing your module

    32KB 2V~3.6V ARM-M0 8KB 64MHz FLASH 30 LQFP-32(7x7)
    Microcontrollers (MCU/MPU/SOC) ROHS
    """

    # ----------------------------------------
    #     modules, interfaces, parameters
    # ----------------------------------------
    # TODO: Change auto-generated interface types to actual high level types
    NRST: F.Electrical
    PA0: F.Electrical
    PA1: F.Electrical
    PA10: F.Electrical
    PA11PA9: F.Electrical
    PA12PA10: F.Electrical
    PA13: F.Electrical
    PA14_BOOT0: F.Electrical
    PA15: F.Electrical
    PA2: F.Electrical
    PA3: F.Electrical
    PA4: F.Electrical
    PA5: F.Electrical
    PA6: F.Electrical
    PA7: F.Electrical
    PA8: F.Electrical
    PA9: F.Electrical
    PB0: F.Electrical
    PB1: F.Electrical
    PB2: F.Electrical
    PB3: F.Electrical
    PB4: F.Electrical
    PB5: F.Electrical
    PB6: F.Electrical
    PB7: F.Electrical
    PB8: F.Electrical
    PB9: F.Electrical
    PC14_OSC32IN: F.Electrical
    PC15_OSC32OUT: F.Electrical
    PC6: F.Electrical
    VDD_VDDA: F.Electrical
    VSS_VSSA: F.Electrical

    # ----------------------------------------
    #                 traits
    # ----------------------------------------
    designator_prefix = L.f_field(F.has_designator_prefix_defined)("U")
    descriptive_properties = L.f_field(F.has_descriptive_properties_defined)(
        {
            DescriptiveProperties.manufacturer: "STMicroelectronics",
            DescriptiveProperties.partno: "STM32G030K6T6",
        }
    )
    datasheet = L.f_field(F.has_datasheet_defined)(
        "https://wmsc.lcsc.com/wmsc/upload/file/pdf/v2/lcsc/2304140030_STMicroelectronics-STM32G030K6T6_C529331.pdf"
    )

    @L.rt_field
    def pin_association_heuristic(self):
        return F.has_pin_association_heuristic_lookup_table(
            mapping={
                self.PB9: ["PB9"],
                self.PA3: ["PA3"],
                self.PA4: ["PA4"],
                self.PA5: ["PA5"],
                self.PA6: ["PA6"],
                self.PA7: ["PA7"],
                self.PB0: ["PB0"],
                self.PB1: ["PB1"],
                self.PB2: ["PB2"],
                self.PA8: ["PA8"],
                self.PA9: ["PA9"],
                self.PC14_OSC32IN: ["PC14-OSC32IN"],
                self.PC6: ["PC6"],
                self.PA10: ["PA10"],
                self.PA11PA9: ["PA11[PA9]"],
                self.PA12PA10: ["PA12[PA10]"],
                self.PA13: ["PA13"],
                self.PA14_BOOT0: ["PA14-BOOT0"],
                self.PA15: ["PA15"],
                self.PB3: ["PB3"],
                self.PB4: ["PB4"],
                self.PB5: ["PB5"],
                self.PC15_OSC32OUT: ["PC15-OSC32OUT"],
                self.PB6: ["PB6"],
                self.PB7: ["PB7"],
                self.PB8: ["PB8"],
                self.VDD_VDDA: ["VDD/VDDA"],
                self.VSS_VSSA: ["VSS/VSSA"],
                self.NRST: ["NRST"],
                self.PA0: ["PA0"],
                self.PA1: ["PA1"],
                self.PA2: ["PA2"],
            },
            accept_prefix=False,
            case_sensitive=False,
        )

    def __preinit__(self):
        # ------------------------------------
        #           connections
        # ------------------------------------

        # ------------------------------------
        #          parametrization
        # ------------------------------------
        pass

```
❯ faebryk libadd WJ2EDGK-5.08-3 module --mfr
![image](https://github.com/user-attachments/assets/336f98e4-b80f-4fdf-b7b7-e2bd367bc070)
```python
# This file is part of the faebryk project
# SPDX-License-Identifier: MIT

import logging

import faebryk.library._F as F  # noqa: F401
from faebryk.core.module import Module
from faebryk.libs.library import L  # noqa: F401
from faebryk.libs.picker.picker import DescriptiveProperties
from faebryk.libs.units import P  # noqa: F401

logger = logging.getLogger(__name__)


class Ningbo_Kangnex_Elec_WJ2EDGK_5_08_3P(Module):
    """
    TODO: Docstring describing your module

    3 1 5.08mm 1x3P Green Plug P=5.08mm
    Pluggable System Terminal Block ROHS
    """

    # ----------------------------------------
    #     modules, interfaces, parameters
    # ----------------------------------------
    # TODO: Change auto-generated interface types to actual high level types
    unnamed = L.list_field(3, F.Electrical)

    # ----------------------------------------
    #                 traits
    # ----------------------------------------
    designator_prefix = L.f_field(F.has_designator_prefix_defined)("P")
    descriptive_properties = L.f_field(F.has_descriptive_properties_defined)(
        {
            DescriptiveProperties.manufacturer: "Ningbo Kangnex Elec",
            DescriptiveProperties.partno: "WJ2EDGK-5.08-3P",
        }
    )
    datasheet = L.f_field(F.has_datasheet_defined)(
        "https://wmsc.lcsc.com/wmsc/upload/file/pdf/v2/lcsc/1912251642_Ningbo-Kangnex-Elec-WJ2EDGK-5-08-3P_C71371.pdf"
    )

    @L.rt_field
    def pin_association_heuristic(self):
        return F.has_pin_association_heuristic_lookup_table(
            mapping={
                self.unnamed[0]: ["1"],
                self.unnamed[1]: ["2"],
                self.unnamed[2]: ["3"],
            },
            accept_prefix=False,
            case_sensitive=False,
        )

    def __preinit__(self):
        # ------------------------------------
        #           connections
        # ------------------------------------

        # ------------------------------------
        #          parametrization
        # ------------------------------------
        pass

```

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
