### PR TITLE
CI: explicity execute pre-commit in CI on PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+name: pre-commit
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  run-pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit
+      run: pre-commit run --all-files
+
+    - name: Fail on diff after pre-commit is run
+      run: git diff --exit-code

--- a/src/faebryk/core/node.py
+++ b/src/faebryk/core/node.py
@@ -337,7 +337,7 @@ class Node(FaebrykLibObject, metaclass=PostInitCaller):
                 raise FieldConstructionError(
                     self,
                     name,
-                    f"An exception occurred while constructing field \"{name}\"",
+                    f'An exception occurred while constructing field "{name}"',
                 ) from e
 
         nonrt, rt = partition(lambda x: isinstance(x[1], rt_field), clsfields.items())


### PR DESCRIPTION
# Description

Explicitly run pre-commit in CI on every task.
This means someone not having `pre-commit` goes from being bad for us to just bad for them. Ideal 👌

Fixes # (issue)

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
