### PR TITLE
Library: PoweredLED: Option to move resistor on A or K side

### DIFF
--- a/src/faebryk/library/LED.py
+++ b/src/faebryk/library/LED.py
@@ -69,10 +69,16 @@ class LED(F.Diode):
         resistor.resistance.merge(
             self.get_needed_series_resistance_for_current_limit(input_voltage),
         )
+        resistor.allow_removal_if_zero()
 
     def connect_via_current_limiting_resistor_to_power(
         self, resistor: F.Resistor, power: F.ElectricPower, low_side: bool
     ):
+        if low_side:
+            self.anode.connect(power.hv)
+        else:
+            self.cathode.connect(power.lv)
+
         self.connect_via_current_limiting_resistor(
             power.voltage,
             resistor,

--- a/src/faebryk/library/LEDIndicator.py
+++ b/src/faebryk/library/LEDIndicator.py
@@ -16,9 +16,18 @@ class LEDIndicator(Module):
 
     led: F.PoweredLED
 
-    # TODO make generic
-    power_switch = L.f_field(F.PowerSwitchMOSFET)(lowside=True, normally_closed=False)
+    power_switch = L.f_field(F.PowerSwitch)(normally_closed=False)
+
+    def __init__(self, use_mosfet: bool = True):
+        self._use_mosfet = use_mosfet
 
     def __preinit__(self):
         self.power_in.connect_via(self.power_switch, self.led.power)
         self.power_switch.logic_in.connect(self.logic_in)
+
+        if self._use_mosfet:
+            self.power_switch.specialize(
+                F.PowerSwitchMOSFET(lowside=True, normally_closed=False)
+            )
+        else:
+            self.power_switch.specialize(F.PowerSwitchStatic())

--- a/src/faebryk/library/PoweredLED.py
+++ b/src/faebryk/library/PoweredLED.py
@@ -11,12 +11,17 @@ class PoweredLED(Module):
     current_limiting_resistor: F.Resistor
     led: F.LED
 
+    def __init__(self, low_side_resistor: bool = True):
+        self.low_side_resistor = low_side_resistor
+
     def __preinit__(self):
-        self.power.hv.connect(self.led.anode)
+        self.power.hv.connect(
+            self.led.anode
+        ) if self.low_side_resistor else self.power.lv.connect(self.led.cathode)
         self.led.connect_via_current_limiting_resistor_to_power(
             self.current_limiting_resistor,
             self.power,
-            low_side=True,
+            low_side=self.low_side_resistor,
         )
         self.current_limiting_resistor.allow_removal_if_zero()
 

--- a/src/faebryk/library/PoweredLED.py
+++ b/src/faebryk/library/PoweredLED.py
@@ -12,18 +12,14 @@ class PoweredLED(Module):
     led: F.LED
 
     def __init__(self, low_side_resistor: bool = True):
-        self.low_side_resistor = low_side_resistor
+        self._low_side_resistor = low_side_resistor
 
     def __preinit__(self):
-        self.power.hv.connect(
-            self.led.anode
-        ) if self.low_side_resistor else self.power.lv.connect(self.led.cathode)
         self.led.connect_via_current_limiting_resistor_to_power(
             self.current_limiting_resistor,
             self.power,
-            low_side=self.low_side_resistor,
+            low_side=self._low_side_resistor,
         )
-        self.current_limiting_resistor.allow_removal_if_zero()
 
     @L.rt_field
     def can_bridge(self):

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -212,5 +212,5 @@ from faebryk.library.PowerSwitchStatic import PowerSwitchStatic
 from faebryk.library.ESP32_C3_MINI_1_Reference_Design import ESP32_C3_MINI_1_Reference_Design
 from faebryk.library.USB_C_5V_PSU import USB_C_5V_PSU
 from faebryk.library.USB_C_PowerOnly import USB_C_PowerOnly
-from faebryk.library.LEDIndicator import LEDIndicator
 from faebryk.library.Powered_Relay import Powered_Relay
+from faebryk.library.LEDIndicator import LEDIndicator


### PR DESCRIPTION
# Library: PoweredLED: Option to move resistor on A or K side

## Description

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
