### PR TITLE
Lib: kicad: fileformat: Add support for groups

### DIFF
--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -949,6 +949,13 @@ class C_kicad_pcb_file(SEXP_File):
         class C_arc_segment(C_segment):
             mid: C_xy
 
+        @dataclass(kw_only=True)
+        class C_group:
+            name: Optional[str] = field(**sexp_field(positional=True), default=None)
+            uuid: UUID
+            locked: Optional[bool] = None
+            members: list[UUID]
+
         version: int = field(**sexp_field(assert_value=20240108))
         generator: str
         generator_version: str
@@ -1144,6 +1151,9 @@ class C_kicad_pcb_file(SEXP_File):
             **sexp_field(multidict=True), default_factory=list
         )
         gr_texts: list[C_text] = field(
+            **sexp_field(multidict=True), default_factory=list
+        )
+        groups: list[C_group] = field(
             **sexp_field(multidict=True), default_factory=list
         )
 

--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -1164,8 +1164,8 @@ class C_kicad_pcb_file(SEXP_File):
 class C_kicad_footprint_file(SEXP_File):
     @dataclass(kw_only=True)
     class C_footprint_in_file(C_footprint):
-        descr: str
-        tags: list[str]
+        descr: Optional[str] = None
+        tags: Optional[list[str]] = None
         version: int = field(**sexp_field(assert_value=20240108), default=20240108)
         generator: str
         generator_version: str


### PR DESCRIPTION
# Lib: kicad: fileformat: Add support for groups

## Description

Nested groups in KiCad is possible, this is just a new group with the UUIDs of the nested groups in the members list.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
