### PR TITLE
Libs: KiCad: Fileformat: Fix missing defaults

### DIFF
--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -583,7 +583,7 @@ class C_footprint:
         at: C_xyr
         layer: C_text_layer
         hide: bool = False
-        uuid: UUID
+        uuid: UUID = field(default_factory=gen_uuid)
         effects: C_effects
 
     @dataclass
@@ -591,7 +591,7 @@ class C_footprint:
         stroke: C_stroke
         fill: E_fill
         layer: str
-        uuid: UUID
+        uuid: UUID = field(default_factory=gen_uuid)
 
     @dataclass(kw_only=True)
     class C_pad:
@@ -1168,7 +1168,7 @@ class C_kicad_footprint_file(SEXP_File):
         tags: Optional[list[str]] = None
         version: int = field(**sexp_field(assert_value=20240108), default=20240108)
         generator: str
-        generator_version: str
+        generator_version: str = ""
         tedit: Optional[str] = None
 
     footprint: C_footprint_in_file


### PR DESCRIPTION
# Libs: KiCad: Fileformat: Fix missing defaults

# Description

Some of KiCads default library footprints are missing these values :roll_eyes: 

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
