### PR TITLE
Exporter: Cross-platform KiCad footprint paths

### DIFF
--- a/src/faebryk/exporters/pcb/kicad/pcb.py
+++ b/src/faebryk/exporters/pcb/kicad/pcb.py
@@ -14,6 +14,7 @@ from faebryk.libs.kicad.fileformats import (
 )
 from faebryk.libs.kicad.fileformats_common import C_effects, C_wh
 from faebryk.libs.kicad.fileformats_version import kicad_footprint_file
+from faebryk.libs.kicad.paths import GLOBAL_FP_DIR_PATH, GLOBAL_FP_LIB_PATH
 from faebryk.libs.sexp.dataclass_sexp import get_parent
 from faebryk.libs.util import (
     KeyErrorNotFound,
@@ -50,9 +51,6 @@ def _get_footprint(identifier: str, fp_lib_path: Path) -> C_footprint:
         dir_path = Path(lib.uri.replace("${KIPRJMOD}", str(fp_lib_path.parent)))
     except KeyErrorNotFound:
         # non-local lib, search in kicad global lib
-        # TODO don't hardcode path
-        GLOBAL_FP_LIB_PATH = Path("~/.config/kicad/8.0/fp-lib-table").expanduser()
-        GLOBAL_FP_DIR_PATH = Path("/usr/share/kicad/footprints")
         global_fp_lib_table = C_kicad_fp_lib_table_file.loads(GLOBAL_FP_LIB_PATH)
         lib = find(global_fp_lib_table.fp_lib_table.libs, lambda x: x.name == lib_id)
         dir_path = Path(

--- a/src/faebryk/exporters/schematic/kicad/transformer.py
+++ b/src/faebryk/exporters/schematic/kicad/transformer.py
@@ -36,6 +36,7 @@ from faebryk.libs.kicad.fileformats_sch import (
     C_rect,
     C_stroke,
 )
+from faebryk.libs.kicad.paths import GLOBAL_FP_DIR_PATH, GLOBAL_FP_LIB_PATH
 from faebryk.libs.sexp.dataclass_sexp import dataclass_dfs
 from faebryk.libs.util import (
     cast_assert,
@@ -201,11 +202,6 @@ class SchTransformer:
             fp_lib_table_paths = [Path(p) for p in fp_lib_tables]
 
         # non-local lib, search in kicad global lib
-        # TODO don't hardcode path
-        # TODO: doesn't work on OSx. Make them at least search paths
-        # /Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols/
-        GLOBAL_FP_LIB_PATH = Path("~/.config/kicad/8.0/fp-lib-table").expanduser()
-        GLOBAL_FP_DIR_PATH = Path("/usr/share/kicad/footprints")
         if load_globals:
             fp_lib_table_paths += [GLOBAL_FP_LIB_PATH]
 

--- a/src/faebryk/libs/kicad/paths.py
+++ b/src/faebryk/libs/kicad/paths.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from pathlib import Path
+
+KICAD_VERSION = "8.0"
+
+# footprint library paths
+# ref: https://docs.kicad.org/8.0/en/kicad/kicad.html#config-file-location
+match sys.platform:
+    case "win32":
+        appdata = os.getenv("APPDATA")
+        if appdata is not None:
+            GLOBAL_FP_LIB_PATH = (
+                Path(appdata) / "kicad" / KICAD_VERSION / "fp-lib-table"
+            )
+        else:
+            raise EnvironmentError("APPDATA environment variable not set")
+        # TODO: verify on a windows machine
+        GLOBAL_FP_DIR_PATH = Path(appdata) / "kicad" / KICAD_VERSION / "footprints"
+    case "linux":
+        GLOBAL_FP_LIB_PATH = (
+            Path("~/.config/kicad").expanduser() / KICAD_VERSION / "fp-lib-table"
+        )
+        GLOBAL_FP_DIR_PATH = Path("/usr/share/kicad/footprints")
+    case "darwin":
+        GLOBAL_FP_LIB_PATH = (
+            Path("~/Library/Preferences/kicad").expanduser()
+            / KICAD_VERSION
+            / "fp-lib-table"
+        )
+        GLOBAL_FP_DIR_PATH = Path(
+            "/Applications/KiCad/KiCad.app/Contents/SharedSupport/symbols"
+        )
+    case _:
+        raise EnvironmentError(f"Unsupported platform: {sys.platform}")
+
+if not GLOBAL_FP_LIB_PATH.exists():
+    raise FileNotFoundError(f"Footprint library path not found: {GLOBAL_FP_LIB_PATH}")
+if not GLOBAL_FP_DIR_PATH.exists():
+    raise FileNotFoundError(f"Footprint directory path not found: {GLOBAL_FP_DIR_PATH}")

--- a/src/faebryk/libs/kicad/paths.py
+++ b/src/faebryk/libs/kicad/paths.py
@@ -1,3 +1,6 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 from pathlib import Path

--- a/src/faebryk/libs/kicad/paths.py
+++ b/src/faebryk/libs/kicad/paths.py
@@ -15,7 +15,7 @@ match sys.platform:
             )
         else:
             raise EnvironmentError("APPDATA environment variable not set")
-        # TODO: verify on a windows machine
+        # TODO: check on a windows machine
         GLOBAL_FP_DIR_PATH = Path(appdata) / "kicad" / KICAD_VERSION / "footprints"
     case "linux":
         GLOBAL_FP_LIB_PATH = (
@@ -33,8 +33,3 @@ match sys.platform:
         )
     case _:
         raise EnvironmentError(f"Unsupported platform: {sys.platform}")
-
-if not GLOBAL_FP_LIB_PATH.exists():
-    raise FileNotFoundError(f"Footprint library path not found: {GLOBAL_FP_LIB_PATH}")
-if not GLOBAL_FP_DIR_PATH.exists():
-    raise FileNotFoundError(f"Footprint directory path not found: {GLOBAL_FP_DIR_PATH}")


### PR DESCRIPTION
# Exporter: Cross-platform KiCad footprint paths

# Description

Adds KiCad global footprint paths for non-linux platforms, in place of hardcoded `~/.config` and `/usr/share` paths.

Fixes
```
FileNotFoundError: [Errno 2] No such file or directory:
'/Users/<user>/.config/kicad/8.0/fp-lib-table'
```
on macOS.

TODO: test on Windows

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
