### PR TITLE
Fix geometry rotation

### DIFF
--- a/src/faebryk/libs/geometry/basic.py
+++ b/src/faebryk/libs/geometry/basic.py
@@ -477,8 +477,11 @@ class Geometry:
         R = np.array(((c, -s), (s, c)))
 
         return cls.translate(
-            (-axis[0], -axis[1]),
-            [tuple(R @ np.array(point)) for point in cls.translate(axis, structure)],
+            axis,
+            [
+                tuple(R @ np.array(point))
+                for point in cls.translate((-axis[0], -axis[1]), structure)
+            ],
         )
 
     C = TypeVar("C", tuple[float, float], tuple[float, float, float])

--- a/test/libs/geometry/test_basic.py
+++ b/test/libs/geometry/test_basic.py
@@ -1,0 +1,21 @@
+import pytest
+
+from faebryk.libs.geometry.basic import Geometry
+
+
+@pytest.mark.parametrize(
+    "structure, axis, angle, expected",
+    [
+        # around origin
+        ((1, 0), (0, 0), 90, (0, 1)),
+        ((1, 2), (0, 0), 90, (-2, 1)),
+        ((1, 2), (0, 0), 180, (-1, -2)),
+        # around point
+        ((0, 0), (1, 0), 180, (2, 0)),
+        ((4, 0), (3, 0), 180, (2, 0)),
+    ],
+)
+def test_rotate(structure, axis, angle, expected):
+    rotated = Geometry.rotate(axis, [structure], angle)
+    # rotated = tuple(map(float, rotated[0]))
+    assert rotated[0] == pytest.approx(expected, abs=1e-6)


### PR DESCRIPTION
# Description

`Geometry.rotate` was doing translations out of order, which manifested grossly for off-origin-axes.

This fixes it

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
