### PR TITLE
Fix: Libs: KiCad: Fileformat: Permit `version` key in `fp-lib-table` file to be absent

### DIFF
--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -1343,7 +1343,7 @@ class C_kicad_fp_lib_table_file(SEXP_File):
             options: str
             descr: str
 
-        version: int = field(**sexp_field(assert_value=7))
+        version: int | None = field(default=None, **sexp_field())
         libs: list[C_lib] = field(**sexp_field(multidict=True), default_factory=list)
 
     fp_lib_table: C_fp_lib_table


### PR DESCRIPTION
# Fix: Libs: KiCad: Fileformat: Permit `version` key in `fp-lib-table` file to be absent

# Description

Expected file contents:

```
(fp_lib_table
  (version 7)
  (lib ...)
)
```

On my machine:
```
(fp_lib_table
  (lib ...)
)
```

Resulting in `DecodeError: Failed to decode fp_lib_table`

This allows for decoding in both cases.

TODO: retain the version number check, when present

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
