### PR TITLE
libs: Normalize FuncDict and FuncSet util collections key and value callables

### DIFF
--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -1010,16 +1010,14 @@ class FuncDict[T, U, H: Hashable](collections.abc.MutableMapping[T, U]):
     def __contains__(self, item: T):
         return item in self._keys[self._hasher(item)]
 
-    @property
     def keys(self) -> Iterator[T]:
         yield from chain.from_iterable(self._keys.values())
 
-    @property
     def values(self) -> Iterator[U]:
         yield from chain.from_iterable(self._values.values())
 
     def __iter__(self) -> Iterator[T]:
-        yield from self.keys
+        yield from self.keys()
 
     def __len__(self) -> int:
         return sum(len(v) for v in self._values.values())
@@ -1054,7 +1052,7 @@ class FuncDict[T, U, H: Hashable](collections.abc.MutableMapping[T, U]):
 
     def items(self) -> Iterable[tuple[T, U]]:
         """Iter key-value pairs as items, just like a dict."""
-        yield from zip(self.keys, self.values)
+        yield from zip(self.keys(), self.values())
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
The `keys` and `values` were properties of the `FuncDict` and `FuncSet` classes. To mimic dicts and sets they should be called.

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
