### PR TITLE
Core: Fix pytest rebuilder and improve editable installation detection

### DIFF
--- a/src/faebryk/core/cpp/CMakeLists.txt
+++ b/src/faebryk/core/cpp/CMakeLists.txt
@@ -19,13 +19,17 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # Currently, Scikit-build does not support FindPython, so we convert the
 # provided hints ourselves.
 if(SKBUILD)
-  set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
-  set(Python_LIBRARY "${PYTHON_LIBRARY}")
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+    set(Python_INCLUDE_DIR "${PYTHON_INCLUDE_DIR}")
+    set(Python_LIBRARY "${PYTHON_LIBRARY}")
 endif()
 set(PYBIND11_FINDPYTHON OFF)
 find_package(Python COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
+
+message(STATUS "Python_EXECUTABLE: ${Python_EXECUTABLE}")
+message(STATUS "Python_INCLUDE_DIR: ${Python_INCLUDE_DIR}")
+message(STATUS "Python_LIBRARY: ${Python_LIBRARY}")
 
 # configure ------------------------------------------------------------
 # c++ standard

--- a/test/core/cpp/test_importcpp.py
+++ b/test/core/cpp/test_importcpp.py
@@ -1,8 +1,8 @@
 # This file is part of the faebryk project
 # SPDX-License-Identifier: MIT
 
-from faebryk.core.cpp import add
-
 
 def test_add():
+    from faebryk.core.cpp import add
+
     assert add(1, 2) == 3


### PR DESCRIPTION
- Fix bug where pytest builds would fail because of system vs. venv python difference
- Improve editable installation detection robustness

Fixes # (issue)

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [x] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
