### PR TITLE
Bugfix: Picker: Attach params on ID or MFR pick

### DIFF
--- a/src/faebryk/libs/picker/jlcpcb/picker_lib.py
+++ b/src/faebryk/libs/picker/jlcpcb/picker_lib.py
@@ -2,9 +2,9 @@ import logging
 from enum import Enum
 from typing import Callable
 
-from faebryk.core.parameter import Parameter
 import faebryk.library._F as F
 from faebryk.core.module import Module
+from faebryk.core.parameter import Parameter
 from faebryk.libs.e_series import E_SERIES_VALUES
 from faebryk.libs.picker.jlcpcb.jlcpcb import (
     Component,

--- a/src/faebryk/libs/picker/jlcpcb/picker_lib.py
+++ b/src/faebryk/libs/picker/jlcpcb/picker_lib.py
@@ -2,6 +2,7 @@ import logging
 from enum import Enum
 from typing import Callable
 
+from faebryk.core.parameter import Parameter
 import faebryk.library._F as F
 from faebryk.core.module import Module
 from faebryk.libs.e_series import E_SERIES_VALUES
@@ -216,6 +217,10 @@ _MAPPINGS_BY_TYPE: dict[type[Module], list[MappingParameterDB]] = {
 }
 
 
+def try_get_param_mapping(module: Module) -> list[MappingParameterDB]:
+    return _MAPPINGS_BY_TYPE.get(type(module), [])
+
+
 # Generic pickers ----------------------------------------------------------------------
 
 
@@ -261,7 +266,14 @@ def find_and_attach_by_lcsc_id(module: Module):
             f"Part with LCSC part number {lcsc_pn} has insufficient stock", module
         )
 
-    part.attach(module, [])
+    try:
+        part.attach(module, try_get_param_mapping(module), allow_TBD=True)
+    except Parameter.MergeException as e:
+        # TODO might be better to raise an error that makes the picker give up
+        # but this works for now, just not extremely efficient
+        raise PickError(
+            f"Could not attach part with LCSC part number {lcsc_pn}: {e}", module
+        ) from e
 
 
 def find_component_by_mfr(mfr: str, mfr_pn: str) -> Component:
@@ -323,11 +335,14 @@ def find_and_attach_by_mfr(module: Module):
 
     for part in parts:
         try:
-            part.attach(module, [])
+            part.attach(module, try_get_param_mapping(module), allow_TBD=True)
             return
         except ValueError as e:
             logger.warning(f"Failed to attach component: {e}")
             continue
+        except Parameter.MergeException:
+            # TODO not very efficient
+            pass
 
     raise PickError(
         f"Could not attach any part with manufacturer part number {mfr_pn}", module


### PR DESCRIPTION
# Bugfix: Picker: Attach params on ID or MFR pick

# Description

When picking a part by LCSC ID or MFR attach the parsed parameters to the module.

Fixes # (issue)

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
