### PR TITLE
Core: Range unfold inner const ranges on query

### DIFF
--- a/src/faebryk/core/parameter.py
+++ b/src/faebryk/core/parameter.py
@@ -478,6 +478,13 @@ class Parameter[PV](Node):
     def _max(self):
         raise ValueError(f"Can't get max for {self}")
 
+    @_resolved_self
+    def get_min(self: "Parameter[PV]") -> PV:
+        return self._min()
+
+    def _min(self):
+        raise ValueError(f"Can't get min for {self}")
+
     def with_same_unit(
         self: "Quantity | float | int | LIT_OR_PARAM",
         to_convert: float | int,

--- a/src/faebryk/library/Constant.py
+++ b/src/faebryk/library/Constant.py
@@ -101,7 +101,10 @@ class Constant[PV](Parameter[PV], Parameter[PV].SupportsSetOps):
         return super().try_compress()
 
     def _max(self):
-        return self.value
+        return self
+
+    def _min(self):
+        return self
 
     def _as_unit(self, unit: UnitsContainer, base: int, required: bool) -> str:
         return to_si_str(self.value, unit)

--- a/src/faebryk/library/Range.py
+++ b/src/faebryk/library/Range.py
@@ -36,14 +36,14 @@ class Range[PV: _SupportsRangeOps](Parameter[PV], Parameter[PV].SupportsSetOps):
     @property
     def min(self) -> Parameter[PV]:
         try:
-            return min(self._get_narrowed_bounds())
+            return min(p._min() for p in self._get_narrowed_bounds())
         except (TypeError, ValueError):
             raise self.MinMaxError()
 
     @property
     def max(self) -> Parameter[PV]:
         try:
-            return max(self._get_narrowed_bounds())
+            return max(p._max() for p in self._get_narrowed_bounds())
         except (TypeError, ValueError):
             raise self.MinMaxError()
 
@@ -126,16 +126,20 @@ class Range[PV: _SupportsRangeOps](Parameter[PV], Parameter[PV].SupportsSetOps):
         return type(self)(*self._bounds)
 
     def try_compress(self) -> Parameter[PV]:
+        bounds = self.bounds
         # compress into constant if possible
         if len(set(map(id, self.bounds))) == 1:
-            return Parameter.from_literal(self.bounds[0])
+            return Parameter.from_literal(bounds[0])
         return super().try_compress()
 
     def __contains__(self, other: LIT_OR_PARAM) -> bool:
         return self.min <= other and self.max >= other
 
     def _max(self):
-        return max(p.get_max() for p in self._get_narrowed_bounds())
+        return self.max
+
+    def _min(self):
+        return self.min
 
     def _as_unit(self, unit: UnitsContainer, base: int, required: bool) -> str:
         return (

--- a/src/faebryk/library/Set.py
+++ b/src/faebryk/library/Set.py
@@ -86,6 +86,9 @@ class Set[PV](Parameter[PV], Parameter[PV].SupportsSetOps):
     def _max(self):
         return max(p.get_max() for p in self.params)
 
+    def _min(self):
+        return min(p.get_min() for p in self.params)
+
     def _as_unit(self, unit: UnitsContainer, base: int, required: bool) -> str:
         return (
             "Set("


### PR DESCRIPTION
# Core: Range unfold inner const ranges on query

# Description
Not sure whether this is really necessary at the moment.
Leaving this here until someone needs it or we merge the new params.

Fixes # (issue)

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
