### PR TITLE
Fix: Support EasyEDA symbols with multiple units

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "sexpdata==1.0.2",
     "black~=24.4.2",
     "typing-extensions>=4.6.3,<5.0.0",
-    "easyeda2kicad~=0.8.0",
+    "easyeda2kicad @ git+https://github.com/atopile/easyeda2kicad.py.git",
     "shapely~=2.0.1",
     "freetype-py~=2.4.0",
     "kicadcliwrapper~=1.0.0",


### PR DESCRIPTION
# Fix: Support EasyEDA symbols with multiple units

# Description

Switches to our fork of easyeda2kicad, which includes enhancements not yet available upstream.

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] My PR title is following the [contribution guidelines](/faebryk/faebryk/blob/main/docs/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I ran [Black](../docs/CONTRIBUTING.md#creating-a-pull-request) to format my code

#### Code of Conduct

By submitting this issue, you agree to follow our [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md):

- [ ] I agree to follow this project's [Code of Conduct](/faebryk/faebryk/blob/main/docs/CODE_OF_CONDUCT.md)
